### PR TITLE
SVCPLAN-1670: Configure puppet backups

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash"
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -1,0 +1,15 @@
+---
+name: "pdk-validate"
+on:  # yamllint disable-line rule:truthy
+  - "push"
+  - "pull_request"
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Clone repository"
+        uses: "actions/checkout@v3"
+      - name: "Run pdk validate"
+        uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
+        with:
+          puppet-version: ""

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,14 @@
+---
+name: "yamllint"
+on:  # yamllint disable-line rule:truthy
+  - "push"
+  - "pull_request"
+jobs:
+  lintAllTheThings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v1"
+      - name: "yaml-lint"
+        uses: "ibiqlik/action-yamllint@v3"
+        with:
+          strict: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,11 +19,11 @@ default:
     - bundle -v
     - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.7-Puppet ~> 6:
+validate lint check rubocop-Ruby 2.5.7-Puppet ~> 6:
   stage: syntax
   image: ruby:2.5.7
   script:
-    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - bundle exec rake validate lint check rubocop
   variables:
     PUPPET_GEM_VERSION: '~> 6'
 
@@ -34,4 +34,20 @@ parallel_spec-Ruby 2.5.7-Puppet ~> 6:
     - bundle exec rake parallel_spec
   variables:
     PUPPET_GEM_VERSION: '~> 6'
+
+validate lint check rubocop-Ruby 2.7.2-Puppet ~> 7:
+  stage: syntax
+  image: ruby:2.7.2
+  script:
+    - bundle exec rake validate lint check rubocop
+  variables:
+    PUPPET_GEM_VERSION: '~> 7'
+
+parallel_spec-Ruby 2.7.2-Puppet ~> 7:
+  stage: unit
+  image: ruby:2.7.2
+  script:
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 7'
 

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,7 +25,9 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes
@@ -37,8 +39,8 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/
 /.sync.yml
+/.devcontainer/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -13,21 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
@@ -43,16 +53,6 @@ gems['puppet'] = location_for(puppet_version)
 
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
-
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
-end
 
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # profile_puppet_master
 
-![pdk-validate](https://github.com/andylytical/puppet-profile_puppet_master/workflows/pdk-validate/badge.svg)
-![yamllint](https://github.com/andylytical/puppet-profile_puppet_master/workflows/yamllint/badge.svg)
+[![pdk-validate](https://github.com/ncsa/puppet-profile_puppet_master/actions/workflows/pdk-validate.yml/badge.svg)](https://github.com/ncsa/puppet-profile_puppet_master/actions/workflows/pdk-validate.yml)
+[![yamllint](https://github.com/ncsa/puppet-profile_puppet_master/actions/workflows/yamllint.yml/badge.svg)](https://github.com/ncsa/puppet-profile_puppet_master/actions/workflows/yamllint.yml)
 
 ## Dependencies
-- [ncsa/profile_docker](https;//github.com/ncsa/puppet-profile_docker)
 - [puppetlabs/firewall](https://forge.puppet.com/puppetlabs/firewall)
+- [ncsa/profile_backup](https://github.com/ncsa/puppet-profile_backup)
 
 ## Reference
 [REFERENCE.md](REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,7 @@
 ### Classes
 
 * [`profile_puppet_master`](#profile_puppet_master): Configure host settings on a puppet master
+* [`profile_puppet_master::backup`](#profile_puppet_masterbackup): Configure Pupppet server backups
 
 ## Classes
 
@@ -47,9 +48,21 @@ Hash of file resource parameters that need setuid removed from them
 
 ##### <a name="firewall_allow_from"></a>`firewall_allow_from`
 
-Data type: `Array[ String, 1 ]`
+Data type: `Array[String, 1]`
 
 Array[ String, 1 ]
 Open the firewall for all "sources" in this list
 Format for sources is any valid "source" string in the puppet/firewall module
+
+### <a name="profile_puppet_masterbackup"></a>`profile_puppet_master::backup`
+
+Configure Pupppet server backups
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_puppet_master::backup
+```
 

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 ---
 version: 1.1.x.{build}
+skip_branch_with_pr: true
 branches:
   only:
     - main
@@ -17,7 +18,7 @@ environment:
   matrix:
     -
       RUBY_VERSION: 25-x64
-      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+      CHECK: validate lint check rubocop
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,0 +1,24 @@
+# @summary Configure Pupppet server backups
+#
+# @example
+#   include profile_puppet_master::backup
+class profile_puppet_master::backup {
+  if ( lookup('profile_backup::client::enabled') ) {
+    include profile_backup::client
+
+    profile_backup::client::add_job { 'profile_puppet_master':
+      paths             => [
+        '/etc/puppetlabs',
+        '/var/backups/puppet_enc',
+        # ADD POSTGRES BACKUPS FOR PUPPETDB (UNTIL POSTGRES MODULE USED)
+        '/var/lib/pgsql',
+      ],
+      prehook_commands  => [
+        '/root/bin/enc_adm --bkup',
+      ],
+      posthook_commands => [
+        "find /var/backups/puppet_enc \\( -name '*.sql.gz' \\) -mtime +90 -type f -exec rm -rf {} \\;",
+      ],
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,12 +19,11 @@
 # @example
 #   include profile_puppet_master
 class profile_puppet_master (
-
   Hash               $crons,
   Hash               $files_remove_setuid,
-  Array[ String, 1 ] $firewall_allow_from,
-
+  Array[String, 1] $firewall_allow_from,
 ) {
+  include profile_puppet_master::backup
 
   # Manage crons
   $crons.each | $cron_name, $cron_data | {
@@ -48,5 +47,4 @@ class profile_puppet_master (
       source => $cidr,
     }
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "2.0.0",
-  "template-url": "pdk-default#2.0.0",
-  "template-ref": "tags/2.0.0-0-ge838f1d"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }

--- a/spec/classes/backup_spec.rb
+++ b/spec/classes/backup_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_puppet_master::backup' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,18 @@ RSpec.configure do |c|
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
   end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
 end
 
 # Ensures that a module is defined


### PR DESCRIPTION
This uses `profile_backup::client::add_job` to add a Puppet Master server backup job to Puppet servers.
It also includes upgrading PDK and implementing GitHub actions to this repo.

See https://jira.ncsa.illinois.edu/browse/SVCPLAN-1670

This is being tested on `asd-pup01` & `control-pup01`